### PR TITLE
add non-blocking operation, power management, transmit power control and more

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,53 +1,79 @@
-# Arduino-SI443
-Arduino library for SILICON LABS SI443x.   
+# Si443x ISM Transceiver Library for Arduino
 
-I made it with reference to [this](https://github.com/ADiea/si4432).   
+This library version is an enhancement of the [origial GitHub project](https://github.com/ADiea/si4432) by ahmetipkin. 
+
+It can be an alternative to the [RadioHead library](http://www.airspayce.com/mikem/arduino/RadioHead) when you are focused on the Si443x and need a specific combination of parameters that are not supported by the RadioHeas library (e.g. Manchester encoding).
+
+## Boards
+
+Example of boards with the Silicon Labs Si4430/31/32 chip:
 
 - 2.54mm pitch 433MHz   
- ![SI4432-433MHz-2 54mm](https://user-images.githubusercontent.com/6020549/163330289-770357cd-5bb4-4030-9347-edd0da6f21d3.JPG)
+  ![Si4432-433MHz-2 54mm](https://user-images.githubusercontent.com/6020549/163330289-770357cd-5bb4-4030-9347-edd0da6f21d3.JPG)
 
 - 1.27mm pitch 433MHz   
- ![SI4432-433MHz-1 27mm](https://user-images.githubusercontent.com/6020549/170854841-ab5318ae-7b31-4d11-98d9-719f48a49c36.JPG)
- Pinout is [here](http://www.dorji.com/docs/data/DRF4432F20.pdf).   
+  ![Si4432-433MHz-1 27mm](https://user-images.githubusercontent.com/6020549/170854841-ab5318ae-7b31-4d11-98d9-719f48a49c36.JPG)  
+  [Pinout](http://www.dorji.com/docs/data/DRF4432F20.pdf)   
 
-# Changes from the original
+## Features
 
-- Changed legacy SPI communication to SPI communication with transactions.   
- Legacy SPI communication works fine on ATMega with fixed CPU frequency, but doesn't work on CPUs like STM32 due to overclocking.   
+- Support floating point values for frequency (MHz) and baud rate (kbps).
 
-- Added CS pin parameters to the constructor.   
+- Select modulation type GFSK (default) or OOK.
 
-- Removed receive processing from sendPacket function.   
+- Select Manchester encoding (default off).
 
-- Removed waitForPacket function.   
+- Select packet handling (default on).
 
-- Added SyncWord validation.   
- Sync Word 3 reset value is 0x2D.   
- Sync Word 2 reset value is 0xD4.   
+- Select transmit power (default max).
 
-- Added example code.   
+- Select blocking (default) or non-blocking transmit.
 
+- Select idle mode from standby, sleep, ready (default) and tune.
 
+- Boot config callback for individual chip settings (e.g. antenna switch)
 
-# Wireing
-|SI4432||UNO|MEGA|ESP8266|
-|:-:|:-:|:-:|:-:|:-:|
-|VCC|--|3.3V(*1)|3.3V|3.3V|
-|GND|--|GND|GND|GND|
-|SCK|--|D13(*2)|D52(*2)|IO14|
-|MISO|--|D12|D50|IO12|
-|MOSI|--|D11(*2)|D51(*2)|IO13|
-|SEL|--|D10(*2)|D10(*2)|IO15|
-|SDN|--|D7(*2)|D7(*2)|IO4|
-|IRQ|--|D2|D2|IO5|
+- Boot SyncWord validation:  
+    Sync Word 3 0x2D.  
+    Sync Word 2 0xD4.  
+    Sync Word 1 0x00.  
+    Sync Word 0 0x00.  
+
+- Use SPI transactions. Legacy SPI communication works fine on ATMega with fixed CPU frequency, but doesn't work on CPUs like STM32 due to overclocking.   
+
+- Configurable CS pin parameter.   
+
+- Example code for transmit and receive.
+
+## Breaking Changes
+
+- Support pin 0, use 0xFF when pin is not available.
+
+- Removed delay in turnOn() to allow non-blocking wakeup.
+
+- Removed receive processing from sendPacket function.
+
+- Removed waitForPacket function.
+
+## Wiring
+
+|Si4432||UNO|MEGA|ESP8266|SAMD21|
+|:-:|:-:|:-:|:-:|:-:|:-:|
+|VCC|--|3.3V(*1)|3.3V|3.3V|3.3V|
+|GND|--|GND|GND|GND|GND|
+|SCK|--|D13(*2)|D52(*2)|IO14|SCK|
+|MISO|--|D12|D50|IO12|MISO|
+|MOSI|--|D11(*2)|D51(*2)|IO13|MOSI|
+|/SEL|--|D10(*2)|D10(*2)|IO15|(*3)|
+|SDN|--|D7(*2)|D7(*2)|IO4|(*3)|
+|/IRQ|--|D2|D2|IO5|(*3)|
 
 (*1)   
-UNO's 3.3V output can only supply 50mA.   
-In addition, the output current capacity of UNO-compatible devices is smaller than that of official products.   
-__So this module may not work normally when supplied from the on-board 3v3.__   
+__The Si443X requires up to 30 mA and may not work reliably when supplied from the MCU on-board 3v3 voltage regulator.__   
+UNO's 3.3V output can supply 50 mA but the output current capacity of UNO-compatible devices is typically lower than that of official products.   
 
 (*2)   
-SI4432 is not 5V tolerant.   
-You need level shift from 5V to 3.3V.   
-I used [this](https://www.ti.com/lit/ds/symlink/txs0108e.pdf?ts=1647593549503) for a level shift.   
+Si4432 is not 5V tolerant. You need to level shift between 5V and 3.3V, e.g. with this [level shifter](https://www.ti.com/lit/ds/symlink/txs0108e.pdf?ts=1647593549503).   
 
+(*3)
+Configurable via constructor.

--- a/library.json
+++ b/library.json
@@ -1,15 +1,25 @@
 {
-"name": "Arduino-SI4432",
+"name": "Si4432",
 "frameworks": "Arduino",
-"keywords": "SI4430, SI4431, SI4432",
-"description": "Implement a driver for SILICON LABS SI443x, tested with module SI4432",
+"keywords": "Si4430, Si4431, Si4432",
+"description": "Implement a driver for SILICON LABS SI443x, tested with module Si4432",
 "authors":
 [
+    {
+        "name": "ahmetipkin",
+        "url": "",
+        "maintainer": false
+    },
     {
         "name": "nopnop2002",
         "url": "",
         "maintainer": true
     },
+    {
+        "name": "jensb",
+        "url": "",
+        "maintainer": false
+    }
 ],
 "repository":
 {

--- a/library.properties
+++ b/library.properties
@@ -1,9 +1,9 @@
-name=Arduino-SI4432
-version=1.0.0
-author=nopnop2002
+name=Si4432
+version=1.1.0
+author=jensb
 maintainer=nopnop2002
-sentence=Driver for SILICON LABS SI443x.
-paragraph=Driver for SILICON LABS SI443x.
+sentence=Driver for SILICON LABS Si443x.
+paragraph=Driver for SILICON LABS Si443x.
 category=Communication
 url=https://github.com/nopnop2002/Arduino-SI4432
-architectures=avr,esp8266
+architectures=avr,esp8266,samd

--- a/si4432.h
+++ b/si4432.h
@@ -1,43 +1,69 @@
 /*
- * SI4432 library for Arduino - v0.1
+ * Si4432 library for Arduino
  *
- * Please note that Library uses standard SS pin for NSEL pin on the chip. This is 53 for Mega, 10 for Uno.
- * NOTES:
+ * made by Ahmet (theGanymedes) Ipkin 2014
  *
- * V0.1
- * * Library supports no `custom' changes and usages of GPIO pin. Modify/add/remove your changes if necessary
- * * Radio use variable packet field format with 4 byte address header, first data field as length. Change if necessary
+ * (c) 2022 nopnop2002
+ * (c) 2023 Jens B.
  *
- * made by Ahmet (theGanymedes) Ipkin
- *
- * 2014
+ * SPDX-License-Identifier: MIT
  */
 
 #ifndef si4432_H_
 #define si4432_H_
+
 #include "Arduino.h"
 #include <SPI.h>
 
-/* Now, according to the this design, you must
+/*
+ * To perform a send/receive you must:
+ *
  * 1- Create an instance
- * 2- Call init()
+ * 2- Configure parameters with setXXXX() where defaults are not suitable
+ * 3- Init SPI with init()
+ * 4a- Send with sendPacket()
+ * 4b- Receive with startListening() + isPacketReceived() + getPacketReceived()
  *
  * According to the data sheet, you can change any register value and most will get to work after going into IDLE state and back (to RX/TX)
  * (some are hot - changes right away) I didn't test this - but why not? :)
- * */
+ *
+ * Antenna configuration depends on board. If an antenna switch exists that can be controlled via GPIO the GPIO function must be configured
+ * after init or reset by the application. As internal conditions (e.g. transmit timeout) can also trigger a reset, implementation is best
+ * done by overriding boot(). Here is an example for 1 antenna, 1 switch and separate TX/RX paths:
+ *
+ * setTransmitPower(7, false);               // disable direct-tie
+ * ChangeRegister(REG_GPIO0_CONF,  0b10010); // Tx state output
+ * ChangeRegister(REG_GPIO1_CONF,  0b10101); // Rx state output
+ * ChangeRegister(REG_GPIO2_CONF, 0b100011); // passive input with 200 kOhm pullup
+ *
+ * When the packet handler is enabled the following packet configuration is used:
+ * - 4 byte preamble (0/1 bit sequence)
+ * - 2 byte sync word (0x2DD4)
+ * - 2 byte header, defined with setCommsSignature()
+ * - 1 byte packet length
+ * - variable data bytes
+ * - 1 byte CRC-16 (IBM)
+ *
+ * The default packet configuration can be changed using setConfigCallback() or in the source, see data sheet for more details.
+ *
+ */
 
 class Si4432 {
 public:
 
-	Si4432(uint8_t csPin, uint8_t sdnPin = 0, uint8_t InterruptPin = 0); // when a InterruptPin is given, interrupts are checked with this pin - rather than SPI polling
+	Si4432(uint8_t csPin, uint8_t sdnPin = 0xFF, uint8_t intPin = 0xFF); // when intPin is given, interrupts are checked with this pin - rather than SPI polling
 
-	void setFrequency(unsigned long baseFrequency); // sets the freq. call before boot
-	void setChannel(byte channel); // sets the channel. call before switching to tx or rx mode
-	void setBaudRate(uint16_t kbps); // sets the  bps. call before switching to tx or rx mode - min:1, max: 256
-	bool init(SPIClass* spi = &SPI);
-	void setCommsSignature(uint16_t signature); // used to 'sign' packets with a predetermined signature - call before boot
+	void setFrequency(int frequency); // sets the frequency [MHz], default 433 MHz - call before switching to tx or rx mode
+	void setFrequency(unsigned long frequency); // sets the frequency [MHz], default 433 MHz - call before switching to tx or rx mode
+	void setFrequency(double frequency); // sets the frequency [MHz], default 433 MHz - call before switching to tx or rx mode
+	void setChannel(byte channel); // select a 1 MHz channel rel. to the frequency, default 0 - call before switching to tx or rx mode
+	void setBaudRate(int kbps); // sets the kbps, 1..256, default 100 kbps - call before switching to tx or rx mode
+	void setBaudRate(uint16_t kbps); // sets the kbps, 1..256, default 100 kbps - call before switching to tx or rx mode
+	void setBaudRate(double kbps); // sets the kbps, 1..256, default 100 kbps - call before switching to tx or rx mode
+	bool init(SPIClass* spi = &SPI, uint32_t spiClock = 8000000); // also performs reset and boot to idle mode, spiClock ..10000000
+	void setCommsSignature(uint16_t signature); // set packet header value, default 0xDEAD - call before init/reset
 
-	bool sendPacket(uint8_t length, const byte* data); // switches to Tx mode and sends the package
+	bool sendPacket(uint8_t length = 0, const byte* data = nullptr); // switches to Tx mode and sends the package, length 0..64, length = 0 repeats last package
 
 	void startListening(); // switch to Rx mode (don't block)
 
@@ -52,30 +78,40 @@ public:
 
 	void clearFIFO();
 
-	void softReset();
+	void softReset(); // blocking, also performs boot
 
-	void hardReset();
+	void hardReset(); // blocking for ~17 ms, also performs boot
 
-	void turnOn();
-	void turnOff();
+	void turnOn(); // non-blocking - wakeup takes ~17 ms, use isClockReady to check status
+	void turnOff(); // non-blocking
 
-protected:
-	enum AntennaMode {
-		RXMode = 0x04, TXMode = 0x08, Ready = 0x01, TuneMode = 0x02
+public:
+	enum OperationMode {
+		StandbyMode = 0x00,  // 800 µs wakeup, 450 nA
+		SleepMode   = 0x10,  // 800 µs wakeup,   1 µA, 32 kHz clock on
+		Ready       = 0x01,  // 200 µs wakeup, 800 µA, 30 MHz clock on
+		TuneMode    = 0x02,  // 200 µs wakeup, 8.5 mA, PLL on
+		RXMode      = 0x04,  //    18.5 mA
+		TXMode      = 0x08,  // .. 30.0 mA
+		Reset       = 0x80,
 	};
 
+protected:
 	uint8_t _csPin, _sdnPin, _intPin;
 	SPIClass* _spi;
 
-	uint64_t _freqCarrier;
+	float _freqCarrier;
 	uint8_t _freqChannel;
-	uint16_t _kbps;
+	float _kbps;
 	uint16_t _packageSign;
 
-	void boot(); // sets SPI and pins ready and boot the radio
+public:
+	void boot(); // sets SPI and pins ready and boots the radio
 
-	void switchMode(byte mode);
+protected:
+	void switchMode(byte mode); // set operation mode
 
+public:
 	enum Registers {
 		REG_DEV_TYPE = 0x00,
 		REG_DEV_VERSION = 0x01,
@@ -138,9 +174,9 @@ protected:
 
 		REG_RECEIVED_LENGTH = 0x4B,
 
-		REG_CHARGEPUMP_OVERRIDE = 0x58,
-		REG_DIVIDER_CURRENT_TRIM = 0x59,
-		REG_VCO_CURRENT_TRIM = 0x5A,
+		REG_CHARGEPUMP_OVERRIDE = 0x58,   // not documented in AN440 Rev. 0.9
+		REG_DIVIDER_CURRENT_TRIM = 0x59,  // not documented in AN440 Rev. 0.9
+		REG_VCO_CURRENT_TRIM = 0x5A,      // not documented in AN440 Rev. 0.9
 
 		REG_AGC_OVERRIDE = 0x69,
 
@@ -168,8 +204,86 @@ protected:
 	void ChangeRegister(Registers reg, byte value);
 	byte ReadRegister(Registers reg);
 
+protected:
 	void BurstWrite(Registers startReg, const byte value[], uint8_t length);
 	void BurstRead(Registers startReg, byte value[], uint8_t length);
+
+public:
+	// settings for registers REG_GPIO0_CONF, REG_GPIO1_CONF and REG_GPIO2_CONF
+	enum GPIO {
+		// function, exclusive
+		GPIO_DIGITAL_INPUT    = 0b00011,
+		GPIO_ANALOG_INPUT     = 0b00111,
+		GPIO_TX_STATE_OUTPUT  = 0b10010,
+		GPIO_RX_STATE_OUTPUT  = 0b10101,
+		GPIO_ANTENNA_1_OUTPUT = 0b10111,
+		GPIO_ANTENNA_2_OUTPUT = 0b11000,
+		// options
+		GPIO_INPUT_PULLUP     = 0x20,
+		GPIO_OUTPUT_DRV1      = 0x40,
+		GPIO_OUTPUT_DRV2      = 0x80,
+		GPIO_OUTPUT_DRV3      = 0xC0,
+	};
+
+	// interrupt flags
+	enum INT {
+		// reg REG_INT_STATUS1 / REG_INT_ENABLE1
+		INT_CRCERROR = 0x0001,
+		INT_PKVALID  = 0x0002,
+		INT_PKSENT   = 0x0004,
+		INT_TXFFAEM  = 0x0020,
+		INT_FFERR    = 0x0080,
+		// reg REG_INT_STATUS2 / REG_INT_ENABLE2
+		INT_POR      = 0x0100,
+		INT_CHIPRDY  = 0x0200,
+		INT_SWDET    = 0x8000,
+		INT_PREAVAL  = 0x4000,
+	};
+
+	enum ModulationType {
+		NONE = 0x00,
+		OOK  = 0x01,
+		FSK  = 0x02,
+		GFSK = 0x03,
+	};
+
+public:
+	uint8_t getIntPin() const; // get interrupt pin, returns 0xFF if not set - may be used to attach ISR
+	uint16_t getIntStatus(); // get interrupt flags, also clears pending interrupts - may be used in ISR
+	void enableInt(uint16_t flags); // enable interrupt sources, see enum INT - typically used internally
+
+	void setModulationType(ModulationType modulationType); // sets modulation type GFSK or OOK, default GFSK - call before setting baud rate
+	void setManchesterEncoding(bool enabled, bool inverted = false); // select Manachester encoding, default disabled
+
+	void setPacketHandling(bool enabled, bool lsbFirst = false); // enables packet handling, default on - call before init/reset
+
+	void setConfigCallback(void (*callback)()); // user specific boot config - call before init/reset
+
+	void setTransmitPower(byte level, bool directTie = true); // 0 (min) .. 7 (max), default 7 - call before switching to tx or rx mode
+	void setSendBlocking(bool enabled = true); // make sendPacket block until Tx has completed, default true - call before sendPacket
+	bool waitTransmitCompleted(); // wait for Tx to complete, returns false on timeout
+
+	void setIdleMode(byte mode); // set idle operation mode for after exiting from boot, TX/FIFO or RX/single, default Ready - call before init/sendPacket/startListening
+	byte getDeviceStatus(); // freqerr (bit 3) should not be set
+
+	void reset(bool soft = false); // blocking up to ~17 ms depending on mode, also performs boot
+
+	bool isClockReady(); // check if oscillator is in ready state
+
+protected:
+	uint32_t _spiClock;
+	ModulationType _modulationType;
+	void (*_configCallback)() = nullptr;
+
+	byte _idleMode;
+	byte _transmitPower;
+	bool _directTie;
+	bool _manchesterEnabled;
+	bool _manchesterInverted;
+	bool _packetHandlingEnabled;
+	bool _lsbFirst;
+	bool _sendBlocking;
+	uint32_t _sendStart;
 
 };
 


### PR DESCRIPTION
This is a multi-feature commit. I am aware that this is not good style, but I had to combine most of the changes to make my use case work at all. The existing examples can still be build but I don't have a setup to test if if they still work.

Here is the list of the new features:

- support floating point values for frequency (MHz) and baud rate (kbps)
- support modulation type OOK
- support disabling of the packet handling
- support Manchester encoding
- added function to select transmit power
- support non-blocking transmit
- support power management (idle mode)
- added config callback for individual chip settings (e.g. antenna switch)
- support MCU SAMD21
- support pin 0
- removed delay in turnOn() to allow non-blocking wakeup

In spite of all these changes the project defaults are unchanged. I "only" had to add several overloaded versions for setFrequency() and setBaudRate() make the examples build without error for the SAMD21.

Some  code issues remain:

- Arduino library name may not have "Arduino" at beginning of name -> changed to class name Si4432
- file name (si4432) does not match class name (Si4432) -> should be changed to Si4432 (or Si443x?)
- definitions in header file not ordered by accessibility (public, protected, private) -> should be reordered
- TX example does not directly build for SAMD21 as sprintf (line 24) requires txBuf to be signed char and sendPacket (line 27) requires txBuf to be unsigned char -> add explicit cast

A working use case for the new features can be found in the [project Solar DHT, method SolarDHT::setupRadio](https://github.com/jnsbyr/samd21-solardht/blob/main/SolarDHT.hpp).