### PR TITLE
fix setting transmit power and channel, prevent reset hang, update documentation

### DIFF
--- a/library.json
+++ b/library.json
@@ -2,7 +2,7 @@
     "name": "Si4432",
     "keywords": "Si4430, Si4431, Si4432",
     "description": "Driver for SILICON LABS SI443x ISM transmitter, tested with module Si4432",
-    "version": "1.1.1",
+    "version": "1.1.2",
     "license": "MIT",
     "frameworks": "Arduino",
     "platforms": "*",

--- a/library.json
+++ b/library.json
@@ -1,29 +1,31 @@
 {
-"name": "Si4432",
-"frameworks": "Arduino",
-"keywords": "Si4430, Si4431, Si4432",
-"description": "Implement a driver for SILICON LABS SI443x, tested with module Si4432",
-"authors":
-[
-    {
-        "name": "ahmetipkin",
-        "url": "",
-        "maintainer": false
-    },
-    {
-        "name": "nopnop2002",
-        "url": "",
-        "maintainer": true
-    },
-    {
-        "name": "jensb",
-        "url": "",
-        "maintainer": false
+    "name": "Si4432",
+    "keywords": "Si4430, Si4431, Si4432",
+    "description": "Driver for SILICON LABS SI443x ISM transmitter, tested with module Si4432",
+    "version": "1.1.1",
+    "license": "MIT",
+    "frameworks": "Arduino",
+    "platforms": "*",
+    "headers": "si4432.h",
+    "authors": [
+        {
+            "name": "ahmetipkin",
+            "url": "",
+            "maintainer": false
+        },
+        {
+            "name": "nopnop2002",
+            "url": "",
+            "maintainer": true
+        },
+        {
+            "name": "jensb",
+            "url": "",
+            "maintainer": false
+        }
+    ],
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/nopnop2002/Arduino-SI4432"
     }
-],
-"repository":
-{
-    "type": "git",
-    "url": "https://github.com/nopnop2002/Arduino-SI4432"
-}
 }

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Si4432
-version=1.1.1
+version=1.1.2
 author=jensb
 maintainer=nopnop2002
 sentence=Driver for SILICON LABS Si443x.

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Si4432
-version=1.1.0
+version=1.1.1
 author=jensb
 maintainer=nopnop2002
 sentence=Driver for SILICON LABS Si443x.

--- a/si4432.cpp
+++ b/si4432.cpp
@@ -18,14 +18,10 @@ Si4432::Si4432(uint8_t csPin, uint8_t sdnPin, uint8_t intPin) :
 		_csPin(csPin),
 		_sdnPin(sdnPin),
 		_intPin(intPin),
-		_spi(nullptr),
 		_freqCarrier(433.0),
-		_freqChannel(0),
 		_kbps(100),
-		_packageSign(0xDEAD),
-		_spiClock(0),
+		_freqChannel(0),
 		_modulationType(GFSK),
-		_configCallback(nullptr),
 		_idleMode(Ready),
 		_transmitPower(7),
 		_directTie(true),
@@ -34,7 +30,11 @@ Si4432::Si4432(uint8_t csPin, uint8_t sdnPin, uint8_t intPin) :
 		_packetHandlingEnabled(true),
 		_lsbFirst(false),
 		_sendBlocking(true),
-		_sendStart(0) {
+		_spi(nullptr),
+		_spiClock(0),
+		_packageSign(0xDEAD),
+		_sendStart(0),
+		_configCallback(nullptr) {
 }
 
 void Si4432::setFrequency(int frequency) {

--- a/si4432.cpp
+++ b/si4432.cpp
@@ -109,7 +109,7 @@ bool Si4432::init(SPIClass* spi, uint32_t spiClock) {
 	_spi->begin();
 
 #ifdef DEBUG
-	Serial.println("SPI is initialized now.");
+	Serial.println("SPI initialized");
 #endif
 
 	reset();
@@ -170,27 +170,27 @@ void Si4432::boot() {
 
 	// backup current settings
 	byte oldTransmitPower = _transmitPower;
-	_transmitPower = 0;
+	_transmitPower = 0xFF;
 	float oldFreqCarrier = _freqCarrier;
 	_freqCarrier = 0;
 	float oldKbps = _kbps;
 	_kbps = 0;
-	uint8_t oldFreqChannel = _freqChannel;
-	_freqChannel = 0;
+	uint16_t oldFreqChannel = _freqChannel;
+	_freqChannel = 0xFFFF;
 
 	if (_configCallback) {
 		_configCallback();
 	}
 
 	// perform missing config
-	if (_transmitPower == 0)
-		setTransmitPower(oldTransmitPower, _directTie); // default max power, direct-tie enabled
+	if (_transmitPower == 0xFF)
+		setTransmitPower(oldTransmitPower, _directTie); // default max power (7), direct-tie enabled
 	if (_freqCarrier == 0)
-  	setFrequency(oldFreqCarrier); // default freq is 433 MHz
+		setFrequency(oldFreqCarrier); // default freq is 433 MHz
 	if (_kbps == 0)
-  	setBaudRate(oldKbps); // default baud rate is 100 kpbs
-	if (_freqChannel == 0)
-	  setChannel(oldFreqChannel); // default channel is 0
+		setBaudRate(oldKbps); // default baud rate is 100 kpbs
+	if (_freqChannel == 0xFFFF)
+		setChannel((byte)oldFreqChannel); // default channel is 0
 
 	switchMode(_idleMode);
 }
@@ -207,8 +207,8 @@ bool Si4432::sendPacket(uint8_t length, const byte* data) {
 			BurstWrite(REG_FIFO, data, length);
 		}
 
-    // enable interrupt for package sent
-    enableInt(INT_PKSENT);
+		// enable interrupt for package sent
+		enableInt(INT_PKSENT);
 
 		// read interrupt registers to clean them
 		getIntStatus();
@@ -272,6 +272,7 @@ void Si4432::getPacketReceived(uint8_t* length, byte* readData) {
 }
 
 void Si4432::setChannel(byte channel) {
+	_freqChannel = channel;
 	ChangeRegister(REG_FREQCHANNEL, channel);
 }
 

--- a/si4432.h
+++ b/si4432.h
@@ -50,42 +50,13 @@
 
 class Si4432 {
 public:
+	enum ModulationType {
+		NONE = 0x00,
+		OOK  = 0x01,
+		FSK  = 0x02,
+		GFSK = 0x03,
+	};
 
-	Si4432(uint8_t csPin, uint8_t sdnPin = 0xFF, uint8_t intPin = 0xFF); // when intPin is given, interrupts are checked with this pin - rather than SPI polling
-
-	void setFrequency(int frequency); // sets the frequency [MHz], default 433 MHz - call before switching to tx or rx mode
-	void setFrequency(unsigned long frequency); // sets the frequency [MHz], default 433 MHz - call before switching to tx or rx mode
-	void setFrequency(double frequency); // sets the frequency [MHz], default 433 MHz - call before switching to tx or rx mode
-	void setChannel(byte channel); // select a 1 MHz channel rel. to the frequency, default 0 - call before switching to tx or rx mode
-	void setBaudRate(int kbps); // sets the kbps, 1..256, default 100 kbps - call before switching to tx or rx mode
-	void setBaudRate(uint16_t kbps); // sets the kbps, 1..256, default 100 kbps - call before switching to tx or rx mode
-	void setBaudRate(double kbps); // sets the kbps, 1..256, default 100 kbps - call before switching to tx or rx mode
-	bool init(SPIClass* spi = &SPI, uint32_t spiClock = 8000000); // also performs reset and boot to idle mode, spiClock ..10000000
-	void setCommsSignature(uint16_t signature); // set packet header value, default 0xDEAD - call before init/reset
-
-	bool sendPacket(uint8_t length = 0, const byte* data = nullptr); // switches to Tx mode and sends the package, length 0..64, length = 0 repeats last package
-
-	void startListening(); // switch to Rx mode (don't block)
-
-	bool isPacketReceived(); // check for the packet received flags
-
-	void getPacketReceived(uint8_t* length, byte* readData); // read from FIFO
-
-	void readAll();
-
-	void clearTxFIFO();
-	void clearRxFIFO();
-
-	void clearFIFO();
-
-	void softReset(); // blocking, also performs boot
-
-	void hardReset(); // blocking for ~17 ms, also performs boot
-
-	void turnOn(); // non-blocking - wakeup takes ~17 ms, use isClockReady to check status
-	void turnOff(); // non-blocking
-
-public:
 	enum OperationMode {
 		StandbyMode = 0x00,  // 800 µs wakeup, 450 nA
 		SleepMode   = 0x10,  // 800 µs wakeup,   1 µA, 32 kHz clock on
@@ -96,22 +67,6 @@ public:
 		Reset       = 0x80,
 	};
 
-protected:
-	uint8_t _csPin, _sdnPin, _intPin;
-	SPIClass* _spi;
-
-	float _freqCarrier;
-	uint8_t _freqChannel;
-	float _kbps;
-	uint16_t _packageSign;
-
-public:
-	void boot(); // sets SPI and pins ready and boots the radio
-
-protected:
-	void switchMode(byte mode); // set operation mode
-
-public:
 	enum Registers {
 		REG_DEV_TYPE = 0x00,
 		REG_DEV_VERSION = 0x01,
@@ -198,17 +153,8 @@ public:
 		REG_CHANNEL_STEPSIZE = 0x7A,
 
 		REG_FIFO = 0x7F,
-
 	};
 
-	void ChangeRegister(Registers reg, byte value);
-	byte ReadRegister(Registers reg);
-
-protected:
-	void BurstWrite(Registers startReg, const byte value[], uint8_t length);
-	void BurstRead(Registers startReg, byte value[], uint8_t length);
-
-public:
 	// settings for registers REG_GPIO0_CONF, REG_GPIO1_CONF and REG_GPIO2_CONF
 	enum GPIO {
 		// function, exclusive
@@ -240,40 +186,71 @@ public:
 		INT_PREAVAL  = 0x4000,
 	};
 
-	enum ModulationType {
-		NONE = 0x00,
-		OOK  = 0x01,
-		FSK  = 0x02,
-		GFSK = 0x03,
-	};
+	Si4432(uint8_t csPin, uint8_t sdnPin = 0xFF, uint8_t intPin = 0xFF); // when intPin is given, interrupts are checked with this pin - rather than SPI polling
 
-public:
 	uint8_t getIntPin() const; // get interrupt pin, returns 0xFF if not set - may be used to attach ISR
 	uint16_t getIntStatus(); // get interrupt flags, also clears pending interrupts - may be used in ISR
 	void enableInt(uint16_t flags); // enable interrupt sources, see enum INT - typically used internally
 
+	void setFrequency(int frequency); // sets the frequency [MHz], default 433 MHz - call before switching to tx or rx mode
+	void setFrequency(unsigned long frequency); // sets the frequency [MHz], default 433 MHz - call before switching to tx or rx mode
+	void setFrequency(double frequency); // sets the frequency [MHz], default 433 MHz - call before switching to tx or rx mode
+	void setChannel(byte channel); // select a 1 MHz channel rel. to the frequency, default 0 - call before switching to tx or rx mode
+
 	void setModulationType(ModulationType modulationType); // sets modulation type GFSK or OOK, default GFSK - call before setting baud rate
 	void setManchesterEncoding(bool enabled, bool inverted = false); // select Manachester encoding, default disabled
+	void setBaudRate(int kbps); // sets the kbps, 1..256, default 100 kbps - call before switching to tx or rx mode
+	void setBaudRate(uint16_t kbps); // sets the kbps, 1..256, default 100 kbps - call before switching to tx or rx mode
+	void setBaudRate(double kbps); // sets the kbps, 1..256, default 100 kbps - call before switching to tx or rx mode
 
 	void setPacketHandling(bool enabled, bool lsbFirst = false); // enables packet handling, default on - call before init/reset
+	void setCommsSignature(uint16_t signature); // set packet header value, default 0xDEAD - call before init/reset
 
 	void setConfigCallback(void (*callback)()); // user specific boot config - call before init/reset
+	bool init(SPIClass* spi = &SPI, uint32_t spiClock = 8000000); // also performs reset and boot to idle mode, spiClock ..10000000
 
 	void setTransmitPower(byte level, bool directTie = true); // 0 (min) .. 7 (max), default 7 - call before switching to tx or rx mode
 	void setSendBlocking(bool enabled = true); // make sendPacket block until Tx has completed, default true - call before sendPacket
+	bool sendPacket(uint8_t length = 0, const byte* data = nullptr); // switches to Tx mode and sends the package, length 0..64, length = 0 repeats last package
 	bool waitTransmitCompleted(); // wait for Tx to complete, returns false on timeout
 
+	void startListening(); // switch to Rx mode (don't block)
+	bool isPacketReceived(); // check for the packet received flags
+	void getPacketReceived(uint8_t* length, byte* readData); // read from FIFO
+
+	void switchMode(byte mode); // set operation mode
 	void setIdleMode(byte mode); // set idle operation mode for after exiting from boot, TX/FIFO or RX/single, default Ready - call before init/sendPacket/startListening
 	byte getDeviceStatus(); // freqerr (bit 3) should not be set
 
-	void reset(bool soft = false); // blocking up to ~17 ms depending on mode, also performs boot
+	void readAll();
 
+	void clearTxFIFO();
+	void clearRxFIFO();
+	void clearFIFO();
+
+	void reset(bool soft = false); // blocking up to ~17 ms depending on mode, also performs boot
+	void softReset(); // blocking, also performs boot
+	void hardReset(); // blocking for ~17 ms, also performs boot
+
+	void turnOn();  // non-blocking - wakeup takes ~17 ms, use isClockReady to check status
+	void turnOff(); // non-blocking
 	bool isClockReady(); // check if oscillator is in ready state
+	void boot(); // sets SPI and pins ready and boots the radio
+
+	void ChangeRegister(Registers reg, byte value);
+	byte ReadRegister(Registers reg);
 
 protected:
-	uint32_t _spiClock;
+	void BurstWrite(Registers startReg, const byte value[], uint8_t length);
+	void BurstRead(Registers startReg, byte value[], uint8_t length);
+
+	uint8_t _csPin, _sdnPin, _intPin;
+
+	float _freqCarrier;
+	float _kbps;
+	uint8_t _freqChannel;
+
 	ModulationType _modulationType;
-	void (*_configCallback)() = nullptr;
 
 	byte _idleMode;
 	byte _transmitPower;
@@ -283,7 +260,14 @@ protected:
 	bool _packetHandlingEnabled;
 	bool _lsbFirst;
 	bool _sendBlocking;
+
+	SPIClass* _spi;
+	uint32_t _spiClock;
+
+	uint16_t _packageSign;
 	uint32_t _sendStart;
+
+	void (*_configCallback)() = nullptr;
 
 };
 

--- a/si4432.h
+++ b/si4432.h
@@ -282,7 +282,7 @@ protected:
 
 	float _freqCarrier;
 	float _kbps;
-	uint8_t _freqChannel;
+	uint16_t _freqChannel;
 
 	ModulationType _modulationType;
 

--- a/si4432.h
+++ b/si4432.h
@@ -186,41 +186,68 @@ public:
 		INT_PREAVAL  = 0x4000,
 	};
 
-	Si4432(uint8_t csPin, uint8_t sdnPin = 0xFF, uint8_t intPin = 0xFF); // when intPin is given, interrupts are checked with this pin - rather than SPI polling
+	// when intPin is given, interrupts are checked with this pin - rather than SPI polling
+	Si4432(uint8_t csPin, uint8_t sdnPin = 0xFF, uint8_t intPin = 0xFF);
 
-	uint8_t getIntPin() const; // get interrupt pin, returns 0xFF if not set - may be used to attach ISR
-	uint16_t getIntStatus(); // get interrupt flags, also clears pending interrupts - may be used in ISR
-	void enableInt(uint16_t flags); // enable interrupt sources, see enum INT - typically used internally
+	// get interrupt pin, returns 0xFF if not set - may be used to attach ISR
+	uint8_t getIntPin() const;
+	 // get interrupt flags, see enum INT, also clears pending interrupts - may be used in ISR
+	uint16_t getIntStatus();
+	// enable interrupt sources, see enum INT - typically used internally
+	void enableInt(uint16_t flags);
 
-	void setFrequency(int frequency); // sets the frequency [MHz], default 433 MHz - call before switching to tx or rx mode
-	void setFrequency(unsigned long frequency); // sets the frequency [MHz], default 433 MHz - call before switching to tx or rx mode
-	void setFrequency(double frequency); // sets the frequency [MHz], default 433 MHz - call before switching to tx or rx mode
-	void setChannel(byte channel); // select a 1 MHz channel rel. to the frequency, default 0 - call before switching to tx or rx mode
+	// sets the frequency [MHz], 240..930 MHz, default 433 MHz - call before switching to tx or rx mode
+	void setFrequency(int frequency);
+	// sets the frequency [MHz], 240..930 MHz, default 433 MHz - call before switching to tx or rx mode
+	void setFrequency(unsigned long frequency);
+	// sets the frequency [MHz], 240..930 MHz, default 433 MHz - call before switching to tx or rx mode
+	void setFrequency(double frequency);
+	// select a 1 MHz channel rel. to the frequency, 0..255, default 0 - call before switching to tx or rx mode
+	void setChannel(byte channel);
 
-	void setModulationType(ModulationType modulationType); // sets modulation type GFSK or OOK, default GFSK - call before setting baud rate
-	void setManchesterEncoding(bool enabled, bool inverted = false); // select Manachester encoding, default disabled
-	void setBaudRate(int kbps); // sets the kbps, 1..256, default 100 kbps - call before switching to tx or rx mode
-	void setBaudRate(uint16_t kbps); // sets the kbps, 1..256, default 100 kbps - call before switching to tx or rx mode
-	void setBaudRate(double kbps); // sets the kbps, 1..256, default 100 kbps - call before switching to tx or rx mode
+	// sets modulation type GFSK or OOK, default GFSK - call before setting baud rate
+	void setModulationType(ModulationType modulationType);
+	// select Manachester encoding, default disabled
+	void setManchesterEncoding(bool enabled, bool inverted = false);
+	// sets the bit rate, 1..256 kbps, default 100 kbps - call before switching to tx or rx mode
+	void setBaudRate(int kbps);
+	// sets the bit rate, 1..256 kbps, default 100 kbps - call before switching to tx or rx mode
+	void setBaudRate(uint16_t kbps);
+	// sets the bit rate, 0.123 .. 256 kbps, default 100 kbps - call before switching to tx or rx mode
+	void setBaudRate(double kbps);
 
-	void setPacketHandling(bool enabled, bool lsbFirst = false); // enables packet handling, default on - call before init/reset
-	void setCommsSignature(uint16_t signature); // set packet header value, default 0xDEAD - call before init/reset
+	// enables packet handling, default on - call before init/reset
+	void setPacketHandling(bool enabled, bool lsbFirst = false);
+	// set packet header value, default 0xDEAD - call before init/reset
+	void setCommsSignature(uint16_t signature);
 
-	void setConfigCallback(void (*callback)()); // user specific boot config - call before init/reset
-	bool init(SPIClass* spi = &SPI, uint32_t spiClock = 8000000); // also performs reset and boot to idle mode, spiClock ..10000000
+	// user specific boot config - call before init/reset
+	void setConfigCallback(void (*callback)());
+	// blocking, also performs reset and boot to idle mode, spiClock ..10000000
+	bool init(SPIClass* spi = &SPI, uint32_t spiClock = 8000000);
 
-	void setTransmitPower(byte level, bool directTie = true); // 0 (min) .. 7 (max), default 7 - call before switching to tx or rx mode
-	void setSendBlocking(bool enabled = true); // make sendPacket block until Tx has completed, default true - call before sendPacket
-	bool sendPacket(uint8_t length = 0, const byte* data = nullptr); // switches to Tx mode and sends the package, length 0..64, length = 0 repeats last package
-	bool waitTransmitCompleted(); // wait for Tx to complete, returns false on timeout
+	// 0 (min) .. 7 (max), default 7 - call before switching to tx or rx mode
+	void setTransmitPower(byte level, bool directTie = true);
+	// make sendPacket block until Tx has completed, default true - call before sendPacket
+	void setSendBlocking(bool enabled = true);
+	// switches to Tx mode and sends the package, length 0..64, length = 0 repeats last package
+	bool sendPacket(uint8_t length = 0, const byte* data = nullptr);
+	// wait for Tx to complete, also returns false on transmit timeout
+	bool waitTransmitCompleted();
 
-	void startListening(); // switch to Rx mode (don't block)
-	bool isPacketReceived(); // check for the packet received flags
-	void getPacketReceived(uint8_t* length, byte* readData); // read from FIFO
+	// switch to Rx mode (don't block)
+	void startListening();
+	// check for the packet received flags
+	bool isPacketReceived();
+	// read from FIFO
+	void getPacketReceived(uint8_t* length, byte* readData);
 
-	void switchMode(byte mode); // set operation mode
-	void setIdleMode(byte mode); // set idle operation mode for after exiting from boot, TX/FIFO or RX/single, default Ready - call before init/sendPacket/startListening
-	byte getDeviceStatus(); // freqerr (bit 3) should not be set
+	// set operation mode, see enum OperationMode
+	void switchMode(byte mode);
+	// set idle operation mode to use after completing boot, TX/FIFO or RX/single, StandbyMode/SleepMode/Ready/TuneMode, default Ready - call before init/sendPacket/startListening
+	void setIdleMode(byte mode);
+	// freqerr (bit 3) should not be set, see datasheet
+	byte getDeviceStatus();
 
 	void readAll();
 
@@ -228,14 +255,21 @@ public:
 	void clearRxFIFO();
 	void clearFIFO();
 
-	void reset(bool soft = false); // blocking up to ~17 ms depending on mode, also performs boot
-	void softReset(); // blocking, also performs boot
-	void hardReset(); // blocking for ~17 ms, also performs boot
+	// blocking up to ~17 ms depending on mode, also performs boot
+	void reset(bool soft = false);
+	// blocking, also performs boot
+	void softReset();
+	// blocking for ~17 ms, also performs boot
+	void hardReset();
 
-	void turnOn();  // non-blocking - wakeup takes ~17 ms, use isClockReady to check status
-	void turnOff(); // non-blocking
-	bool isClockReady(); // check if oscillator is in ready state
-	void boot(); // sets SPI and pins ready and boots the radio
+	// non-blocking - wakeup takes ~17 ms, use isClockReady to check status
+	void turnOn();
+	// non-blocking
+	void turnOff();
+	// check if oscillator is in ready state
+	bool isClockReady();
+	// sets SPI and pins ready and boots the radio
+	void boot();
 
 	void ChangeRegister(Registers reg, byte value);
 	byte ReadRegister(Registers reg);


### PR DESCRIPTION
This PR combines 4 changes:

- methods and members in header file order by accessibility and functionality
- moved method comments before declaration and improve some comments
- fix not being able to set the transmit power to level 0 or change the channel via config callback, also includes a fix to assign new channel number to the member variable
- improvement to prevent a indefinite loop waiting for a specific status after reset when calling reset